### PR TITLE
Improve and handle unknown stations better

### DIFF
--- a/TribalKnowledge.md
+++ b/TribalKnowledge.md
@@ -1,0 +1,20 @@
+# Tribal Knowledge
+
+## Unknown Stations
+
+There are at least 2 Unknown StopIDs: `R60` and `R65`. These show up in the feed itself, but are not present in `stops.txt`. 
+
+* `R60`
+
+  * Is the location for Northbound R and N trains between Lexington/59th Street and Queens Plaza, which is in the tunnel/elevated Queensboro bridge section of track. 
+  * The MTA's Google Group on this has had discussion as long ago as 2013, when this stop was removed from `stops.txt` and `stop_times.txt` (approximatel)
+  * https://groups.google.com/g/mtadeveloperresources/search?q=R60
+  * It is known as the "11th Street Cut", or "60th Street Tunnel Connection", and is the result of connecting 2 different (original) agencies lines back when the subway was consolidated: https://en.wikipedia.org/wiki/60th\_Street\_Tunnel\_Connection (BMT to IND)
+
+* `R65`
+
+  * Is the location for Southbound R trains between Whitehall and Court Street, which is the tunnel to Brooklyn
+  * There is no discussion on this StopId on the Google Group, but I'd imagine it's either a deprecated station or similar connection between two former agencies in the same way as R60. 
+ 
+I'll likely either ignore these, or add an extension to `stops.txt` for my own purposes because even if neither is a station, it's interesting data. I'd guess the time to cross the tunnel is a few minutes more than most intra-station times anyway, so could be another piece of data to add in, even if questionably reliable.
+

--- a/makefile
+++ b/makefile
@@ -11,7 +11,7 @@ all:
 	$(GCC) -o $(TARGET) $(PROTOBUFS) $(DEPS) $(MAIN) $(FLAGS)
 
 debug:
-	$(GCC) -g -o $(TARGET_DEBUG) $(PROTOBUFS) $(DEPS) $(MAIN) $(FLAGS)
+	$(GCC) -g -o $(TARGET_DEBUG) -DDEBUG $(PROTOBUFS) $(DEPS) $(MAIN) $(FLAGS)
 
 clean:
 	rm *.o $(TARGET) $(TARGET_DEBUG)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -58,8 +58,8 @@ int main(int argc, char* argv[])
                 args.filenames.push_back(optarg);
 				break;
 			case 's':
-                // TODO: default this out, or use config maybe?
-				args.stops_txt_filename = optarg;
+                // TODO: default this out, or use config maybe?  
+                args.stops_txt_filename = optarg;
 				break;
 		}
 	}

--- a/src/static_data_parser.cpp
+++ b/src/static_data_parser.cpp
@@ -66,9 +66,10 @@ StopName StaticData::get_stop_name(StopId sid){
     // If the id isn't found
 
     // StopName is just a string anyway
-    StopName sname("UNKNOWN");
     if (!stopmap_ptr->count(sid))
     {
+        StopName sname("UNKNOWN: ");
+        sname += sid;
         std::cerr << "ERROR: StopID '" << sid << "' not found in stops.txt!" << std::endl;
         return sname;
     }

--- a/src/trip_map.cpp
+++ b/src/trip_map.cpp
@@ -9,7 +9,9 @@ bool TripMap::add_trip(TripInfo new_ti)
     if (k_trip_map.count(new_ti.trip_id) == 0)
     {
         // Doesn't exist, so just add it
+        #ifdef DEBUG
         std::cout << "add_trip(): Adding trip info for new trip_id: " << new_ti.trip_id << std::endl;
+        #endif
         TripInfoVec tiv;
         tiv.push_back(new_ti);
         k_trip_map[new_ti.trip_id] = tiv;
@@ -39,8 +41,10 @@ bool TripMap::add_trip(TripInfo new_ti)
             // Check if proposed record has newer timestamp than first record in the TIV
             if (tmp.pi.timestamp < new_ti.pi.timestamp)
             {
+                #ifdef DEBUG
                 std::cout << "add_trip(): Inserting at front: new_ti is more recent than most recent existing ti: \n\t" 
                           << tmp << "\n\tvs new_ti:\n\t" << new_ti << std::endl;
+                #endif
                 tiv_existing.insert(itr, new_ti);
                 return true;
             } 
@@ -48,13 +52,17 @@ bool TripMap::add_trip(TripInfo new_ti)
             { 
                 // Records have the same exact timestamp, likely duplicate record, so check it
                 if (new_ti == tmp){
+                    #ifdef DEBUG
                     std::cout << "add_trip(): Duplicate trip, discarding\n" 
                               << "tmp:\t" << tmp << "\nnew:\t" << new_ti << std::endl;
+                    #endif
                     return false;
                 } else {
                     // Should never happen, but just in case...going to log it
+                    #ifdef DEBUG
                     std::cerr << "add_trip(): Timestamps match, but TripInfo structs are different!\n\t"
                               << "tmp:\t" << tmp << "\nnew:\t" << new_ti << std::endl;
+                    #endif
                     itr++;
                 }
             } 
@@ -62,14 +70,17 @@ bool TripMap::add_trip(TripInfo new_ti)
             {
                 // new_ti is just at an older timestamp than this record, so progress onward
                 // Iter to next location, this isn't where we should insert
+                #ifdef DEBUG
                 std::cout << "add_trip(): Additional TripInfo: itering again on timestamp:\n" 
                           << "tmp:\t" << tmp << "\nnew:\t" << new_ti << std::endl;
+                #endif
                 itr++;
             }
 
         }
-        
+        #ifdef DEBUG 
         std::cout << "add_trip(): Inserting at end, iteration complete: \n\t" << tmp << "\n\tfor new_ti:\n\t" << new_ti << std::endl;
+        #endif
         // Will have not itered if it is newest update
         tiv_existing.insert(itr, new_ti);
 


### PR DESCRIPTION
* Adds macro to conditionally print additional logging when using `-DDEBUG` at compile time. Not ideal, but it's helpful for the time being until I use a legitimate logging framework (or similar)
* While I was doing this I came across some unknown station IDs: R60 and R65. I did a little research and found out what they are, documented it as well.
