### PR TITLE
Add Apache log4cxx logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ poller.cpp
 current_status*
 TODO*
 mta_debug
+log4cxx

--- a/README.md
+++ b/README.md
@@ -4,6 +4,15 @@ This is a C++ ocmmand line app designed for tracking the subway in New York. It'
 
 For now the output specification is a command line app that updates in realtime with subway data.
 
+## Dependencies
+
+This should be in a formal dpkg structure but for now:
+
+* c++17
+* Protobuf
+* Apache Log4CXX
+
+
 ## Sources
 
 * `*.proto` files are from https://api.mta.info/#/HelpDocument

--- a/log_config.txt
+++ b/log_config.txt
@@ -1,0 +1,9 @@
+# Set root logger level to DEBUG and its only appender to A1.
+log4j.rootLogger=INFO, A1
+
+# A1 is set to be a ConsoleAppender.
+log4j.appender.A1=org.apache.log4j.ConsoleAppender
+
+# A1 uses PatternLayout.
+log4j.appender.A1.layout=org.apache.log4j.PatternLayout
+log4j.appender.A1.layout.ConversionPattern=%-4r [tid: %t] %-5p - %m%n

--- a/makefile
+++ b/makefile
@@ -11,7 +11,7 @@ all:
 	$(GCC) -o $(TARGET) $(PROTOBUFS) $(DEPS) $(MAIN) $(FLAGS)
 
 debug:
-	$(GCC) -g -o $(TARGET_DEBUG) -DDEBUG $(PROTOBUFS) $(DEPS) $(MAIN) $(FLAGS)
+	$(GCC) -g -o $(TARGET_DEBUG) $(PROTOBUFS) $(DEPS) $(MAIN) $(FLAGS)
 
 clean:
 	rm *.o $(TARGET) $(TARGET_DEBUG)

--- a/makefile
+++ b/makefile
@@ -5,7 +5,7 @@ TARGET_DEBUG=mta_debug
 PROTOBUFS=src/protobufs/gtfs-realtime.pb.cc src/protobufs/nyct-subway.pb.cc
 DEPS=src/basic_structures.cpp src/time_parser.cpp src/utils.cpp src/trip_map.cpp src/static_data_parser.cpp src/file_parser.cpp
 MAIN=src/main.cpp
-FLAGS=-std=c++11 -lprotobuf
+FLAGS=-std=c++17 -lprotobuf -llog4cxx
 
 all:
 	$(GCC) -o $(TARGET) $(PROTOBUFS) $(DEPS) $(MAIN) $(FLAGS)

--- a/mta_static_data/stops.txt
+++ b/mta_static_data/stops.txt
@@ -1424,6 +1424,12 @@ R44S,,86 St,,40.622687,-74.028398,,,0,R44
 R45,,Bay Ridge-95 St,,40.616622,-74.030876,,,1,
 R45N,,Bay Ridge-95 St,,40.616622,-74.030876,,,0,R45
 R45S,,Bay Ridge-95 St,,40.616622,-74.030876,,,0,R45
+R60,,Queensboro Bridge 11th Street Cut,,40.753323,-73.946537,,,0,R60
+R60N,,Queensboro Bridge 11th Street Cut,,40.753323,-73.946537,,,0,R60
+R60S,,Queensboro Bridge 11th Street Cut,,40.753323,-73.946537,,,0,R60
+R65,,Montague Tunnel (Manhattan-Brooklyn),,40.698056,-74.005556,,,0,R65
+R65N,,Montague Tunnel (Manhattan-Brooklyn),,40.698056,-74.005556,,,0,R65
+R65S,,Montague Tunnel (Manhattan-Brooklyn),,40.698056,-74.005556,,,0,R65
 S01,,Franklin Av,,40.680596,-73.955827,,,1,
 S01N,,Franklin Av,,40.680596,-73.955827,,,0,S01
 S01S,,Franklin Av,,40.680596,-73.955827,,,0,S01

--- a/parse_files_in_data_dir.bash
+++ b/parse_files_in_data_dir.bash
@@ -8,7 +8,7 @@ do
     ALL_FILES="$ALL_FILES -f data/$file" 
 done
 
-echo "bash -c \"./mta $ALL_FILES -s mta_static_data/stops.txt >> current_status_all_lines\""
-bash -c "./mta $ALL_FILES -s mta_static_data/stops.txt >> current_status_all_lines"
+echo "bash -c \"./mta $ALL_FILES -l log_config.txt -s mta_static_data/stops.txt >> current_status_all_lines\""
+bash -c "./mta $ALL_FILES -l log_config.txt -s mta_static_data/stops.txt >> current_status_all_lines"
 
 echo "done"

--- a/src/basic_structures.cpp
+++ b/src/basic_structures.cpp
@@ -7,7 +7,7 @@
 #include "basic_structures.hh"
 #include "time_parser.hh"
 
-std::ostream& operator<<(std::ostream& os, TripInfo& ti){
+std::ostream& operator<<(std::ostream& os, const TripInfo& ti){
     std::stringstream ss;
     ss << (ti.is_assigned ? "+ " : "- ")
        << "Train: " << ti.trip_id << ", " << ti.direction << " " << ti.train_line 
@@ -20,7 +20,7 @@ std::ostream& operator<<(std::ostream& os, TripInfo& ti){
     return os;
 }
 
-std::ostream& operator<<(std::ostream& os, TripInfoVec& tiv){
+std::ostream& operator<<(std::ostream& os, const TripInfoVec& tiv){
     std::stringstream ss;
     for (int i = 0; i < tiv.size(); i++){
         ss << "\n\t" << tiv[i];

--- a/src/basic_structures.hh
+++ b/src/basic_structures.hh
@@ -26,8 +26,8 @@ struct TripInfo {
 };
 
 typedef std::vector<TripInfo> TripInfoVec;
-std::ostream& operator<<(std::ostream& os, TripInfo& ti);
-std::ostream& operator<<(std::ostream& os, TripInfoVec& tiv);
+std::ostream& operator<<(std::ostream& os, const TripInfo& ti);
+std::ostream& operator<<(std::ostream& os, const TripInfoVec& tiv);
 
 bool operator==(TripInfo& left, TripInfo& right);
 bool operator!=(TripInfo& left, TripInfo& right);

--- a/src/file_parser.cpp
+++ b/src/file_parser.cpp
@@ -11,8 +11,11 @@
 #include <sstream>
 #include <string>
 
+#include "log4cxx/logger.h"
+
 #include "file_parser.hh"
 
+log4cxx::LoggerPtr fileparser_logger(log4cxx::Logger::getLogger("mta.FileParser"));
 
 // Parse file into protobuf objects
 bool FileParser::parse_file(StaticData* sd)
@@ -25,14 +28,14 @@ bool FileParser::parse_file(StaticData* sd)
 
         if (!data)
         {
-            std::cerr << "Error opening file: " << k_filepath << ", error: " << strerror(errno) << std::endl;
+            LOG4CXX_ERROR(fileparser_logger, "Error opening file: " << k_filepath << ", error: " << strerror(errno));
             return false;
         }
         
         transit_realtime::FeedMessage fmessage;
         if (!fmessage.ParseFromIstream(&data))
         {
-            std::cerr << "Error parsing file: " << k_filepath << ", error: " << strerror(errno) << std::endl;
+            LOG4CXX_ERROR(fileparser_logger, "Error parsing file: " << k_filepath << ", error: " << strerror(errno));
             return false;
         }
         
@@ -80,7 +83,6 @@ bool FileParser::parse_file(StaticData* sd)
                     }
                     k_all_trips.push_back(ti);
                 }
-                
 
                 // TripUpdate parsing for this same Trip!
             }
@@ -91,21 +93,14 @@ bool FileParser::parse_file(StaticData* sd)
         std::sort(k_all_trips.begin(), k_all_trips.end(), sortDepartureTime);
 
         for (int i = 0; i < k_all_trips.size(); i++){
-            std::cout << k_all_trips[i] << std::endl;
+            LOG4CXX_DEBUG(fileparser_logger, k_all_trips[i]);
         }
         
-        // TODO: decided what to do with the below, presently unused and might not need to be
-        // We don't necessarily need JSON, can just use C++ structures etc
-        // Maybe will need to create our own structures of what we care about for subsequent analysis 
-        // good to go from here
-        //std::string json;
-        //google::protobuf::util::MessageToJsonString(trip_descriptions, &json);
-        //std::cout << json << std::endl;
-        std::cout << "Num trips in this file: " << k_all_trips.size() << std::endl;
+        LOG4CXX_INFO(fileparser_logger, "Num trips in this file: " << k_all_trips.size());
     }
     else 
     {
-        std::cerr << "k_filepath has no size! Nothing to parse. k_filepath: '" << k_filepath << "'" << std::endl;
+        LOG4CXX_ERROR(fileparser_logger, "k_filepath has no size! Nothing to parse. k_filepath: '" << k_filepath << "'");
         return false;
     }
 	return true;	

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,6 +5,9 @@
 #include <string>
 #include <unistd.h>
 
+#include "log4cxx/logger.h"
+#include "log4cxx/basicconfigurator.h"
+
 #include "static_data_parser.hh"
 #include "file_parser.hh"
 #include "trip_map.hh"
@@ -27,6 +30,9 @@ static void show_usage(void)
           << "[-f|--filename FILENAME] ... \n"
 		  << std::endl; 
 }
+
+// Set up logger
+log4cxx::LoggerPtr logger(log4cxx::Logger::getLogger("mta_app"));
 
 int main(int argc, char* argv[])
 {
@@ -64,13 +70,16 @@ int main(int argc, char* argv[])
 		}
 	}
 
-	std::cout << "Arguments given:"
-		  << "\nStation: " << args.station
-		  << "\nDirection: " << args.direction
-		  << "\nRoute: " << args.route
-		  << "\nFilenames: " << args.filenames
-		  << "\nStops.txt filename: " << args.stops_txt_filename
-		  << std::endl;
+    log4cxx::BasicConfigurator::configure();
+	LOG4CXX_INFO(logger, "Test");
+    std::stringstream msg;
+    msg << "Arguments given:"
+        << "\nStation: " << args.station
+        << "\nDirection: " << args.direction
+        << "\nRoute: " << args.route
+        << "\nFilenames: " << args.filenames
+        << "\nStops.txt filename: " << args.stops_txt_filename << std::endl;
+    LOG4CXX_INFO(logger, msg.str());
 
     // Get files from MTA here if no filename given
     //if (!args.filename)

--- a/src/static_data_parser.cpp
+++ b/src/static_data_parser.cpp
@@ -3,7 +3,11 @@
 #include <sstream>
 #include <iostream>
 
+#include "log4cxx/logger.h"
+
 #include "static_data_parser.hh"
+
+log4cxx::LoggerPtr stopmap_logger(log4cxx::Logger::getLogger("mta.StopMap"));
 
 StopIdNameMap* get_stop_map(std::string filename){
     // Parses stops.txt file, given as a filename to the function
@@ -70,7 +74,7 @@ StopName StaticData::get_stop_name(StopId sid){
     {
         StopName sname("UNKNOWN: ");
         sname += sid;
-        std::cerr << "ERROR: StopID '" << sid << "' not found in stops.txt!" << std::endl;
+        LOG4CXX_ERROR(stopmap_logger, "ERROR: StopID '" << sid << "' not found in stops.txt!");
         return sname;
     }
 

--- a/src/trip_map.cpp
+++ b/src/trip_map.cpp
@@ -3,15 +3,14 @@
 #include <iostream> 
 #include "trip_map.hh"
 
+log4cxx::LoggerPtr tripmap_logger(log4cxx::Logger::getLogger("mta.TripMap"));
 
 bool TripMap::add_trip(TripInfo new_ti)
 {
     if (k_trip_map.count(new_ti.trip_id) == 0)
     {
         // Doesn't exist, so just add it
-        #ifdef DEBUG
-        std::cout << "add_trip(): Adding trip info for new trip_id: " << new_ti.trip_id << std::endl;
-        #endif
+        LOG4CXX_DEBUG(tripmap_logger, "add_trip(): Adding trip info for new trip_id: " << new_ti.trip_id);
         TripInfoVec tiv;
         tiv.push_back(new_ti);
         k_trip_map[new_ti.trip_id] = tiv;
@@ -28,7 +27,7 @@ bool TripMap::add_trip(TripInfo new_ti)
         // We have to dedupe them
 
         // Let's insert the record into the correct spot in the vector
-        std::cout << "Adding additional trip info for existing trip_id: " << new_ti.trip_id << std::endl;
+        LOG4CXX_DEBUG(tripmap_logger, "Adding additional trip info for existing trip_id: " << new_ti.trip_id);
         TripInfoVec& tiv_existing = k_trip_map[new_ti.trip_id];
 
         // Find correct spot
@@ -41,10 +40,7 @@ bool TripMap::add_trip(TripInfo new_ti)
             // Check if proposed record has newer timestamp than first record in the TIV
             if (tmp.pi.timestamp < new_ti.pi.timestamp)
             {
-                #ifdef DEBUG
-                std::cout << "add_trip(): Inserting at front: new_ti is more recent than most recent existing ti: \n\t" 
-                          << tmp << "\n\tvs new_ti:\n\t" << new_ti << std::endl;
-                #endif
+                LOG4CXX_DEBUG(tripmap_logger, "add_trip(): Inserting at front: new_ti is more recent than most recent existing ti: \n\t" << tmp << "\n\tvs new_ti:\n\t" << new_ti);
                 tiv_existing.insert(itr, new_ti);
                 return true;
             } 
@@ -52,17 +48,12 @@ bool TripMap::add_trip(TripInfo new_ti)
             { 
                 // Records have the same exact timestamp, likely duplicate record, so check it
                 if (new_ti == tmp){
-                    #ifdef DEBUG
-                    std::cout << "add_trip(): Duplicate trip, discarding\n" 
-                              << "tmp:\t" << tmp << "\nnew:\t" << new_ti << std::endl;
-                    #endif
+                    LOG4CXX_DEBUG(tripmap_logger, "add_trip(): Duplicate trip, discarding\n" 
+                            << "tmp:\t" << tmp << "\nnew:\t" << new_ti);
                     return false;
                 } else {
                     // Should never happen, but just in case...going to log it
-                    #ifdef DEBUG
-                    std::cerr << "add_trip(): Timestamps match, but TripInfo structs are different!\n\t"
-                              << "tmp:\t" << tmp << "\nnew:\t" << new_ti << std::endl;
-                    #endif
+                    LOG4CXX_DEBUG(tripmap_logger, "add_trip(): Timestamps match, but TripInfo structs are different!\n\t" << "tmp:\t" << tmp << "\nnew:\t" << new_ti);
                     itr++;
                 }
             } 
@@ -70,17 +61,13 @@ bool TripMap::add_trip(TripInfo new_ti)
             {
                 // new_ti is just at an older timestamp than this record, so progress onward
                 // Iter to next location, this isn't where we should insert
-                #ifdef DEBUG
-                std::cout << "add_trip(): Additional TripInfo: itering again on timestamp:\n" 
-                          << "tmp:\t" << tmp << "\nnew:\t" << new_ti << std::endl;
-                #endif
+                LOG4CXX_DEBUG(tripmap_logger, "add_trip(): Additional TripInfo: itering again on timestamp:\n" 
+                          << "tmp:\t" << tmp << "\nnew:\t" << new_ti);
                 itr++;
             }
 
         }
-        #ifdef DEBUG 
-        std::cout << "add_trip(): Inserting at end, iteration complete: \n\t" << tmp << "\n\tfor new_ti:\n\t" << new_ti << std::endl;
-        #endif
+        LOG4CXX_DEBUG(tripmap_logger, "add_trip(): Inserting at end, iteration complete: \n\t" << tmp << "\n\tfor new_ti:\n\t" << new_ti);
         // Will have not itered if it is newest update
         tiv_existing.insert(itr, new_ti);
 

--- a/src/trip_map.hh
+++ b/src/trip_map.hh
@@ -8,7 +8,10 @@
 #include <string>
 #include <vector>
 
+#include "log4cxx/logger.h"
+
 #include "basic_structures.hh"
+
 
 class TripMap{
     public:


### PR DESCRIPTION
* Converts `std::cout` and `std::cerr` logging to use Apache Log4CXX's `LOG4CXX_INFO` and `LOG4CXX_ERROR`
* Adds default log config with basic setup
* Adds `-v|--verbose` option to use debug logging at runtime (the same is possible using an edited `log_config.txt` of course