### PR TITLE
Log to file, trim down output, add support file for supplementary data

### DIFF
--- a/log_config.txt
+++ b/log_config.txt
@@ -1,9 +1,15 @@
-# Set root logger level to DEBUG and its only appender to A1.
-log4j.rootLogger=INFO, A1
+# Set root logger level to DEBUG and its only appenders
+log4j.rootLogger=INFO, STDOUT, LOGFILE
 
-# A1 is set to be a ConsoleAppender.
-log4j.appender.A1=org.apache.log4j.ConsoleAppender
+# STDOUT is set to be a ConsoleAppender.
+log4j.appender.STDOUT=org.apache.log4j.ConsoleAppender
 
-# A1 uses PatternLayout.
-log4j.appender.A1.layout=org.apache.log4j.PatternLayout
-log4j.appender.A1.layout.ConversionPattern=%-4r [tid: %t] %-5p - %m%n
+# LOGFILE is set to be a ConsoleAppender.
+log4j.appender.LOGFILE=org.apache.log4j.FileAppender
+log4j.appender.LOGFILE.FILE=mta.log
+
+# Both appenders use PatternLayout.
+log4j.appender.STDOUT.layout=org.apache.log4j.PatternLayout
+log4j.appender.STDOUT.layout.ConversionPattern=%-4r [tid: %t] %-5p - %m%n
+log4j.appender.LOGFILE.layout=org.apache.log4j.PatternLayout
+log4j.appender.LOGFILE.layout.ConversionPattern=%-4r [tid: %t] %-5p - %m%n

--- a/mta_static_data/stops.txt.supplement
+++ b/mta_static_data/stops.txt.supplement
@@ -1,0 +1,13 @@
+stop_id,stop_code,stop_name,stop_desc,stop_lat,stop_lon,zone_id,stop_url,location_type,parent_station
+R60,,Queensboro Bridge,,40.616622,-74.030876,,,0,R60
+R60N,,Queensboro Bridge,,40.616622,-74.030876,,,0,R60
+R60S,,Queensboro Bridge,,40.616622,-74.030876,,,0,R60
+R65,,R-train Manhattan-Brooklyn Tunnel,,40.616622,-74.030876,,,0,R65
+R65N,,R-train Manhattan-Brooklyn Tunnel,,40.616622,-74.030876,,,0,R65
+R65S,,R-train Manhattan-Brooklyn Tunnel,,40.616622,-74.030876,,,0,R65
+R60,,Queensboro Bridge 11th Street Cut,,40.753323,-73.946537,,,0,R60
+R60N,,Queensboro Bridge 11th Street Cut,,40.753323,-73.946537,,,0,R60
+R60S,,Queensboro Bridge 11th Street Cut,,40.753323,-73.946537,,,0,R60
+R65,,Montague Tunnel (Manhattan-Brooklyn),,40.698056,-74.005556,,,0,R65
+R65N,,Montague Tunnel (Manhattan-Brooklyn),,40.698056,-74.005556,,,0,R65
+R65S,,Montague Tunnel (Manhattan-Brooklyn),,40.698056,-74.005556,,,0,R65

--- a/parse_files_in_data_dir.bash
+++ b/parse_files_in_data_dir.bash
@@ -8,7 +8,7 @@ do
     ALL_FILES="$ALL_FILES -f data/$file" 
 done
 
-echo "bash -c \"./mta $ALL_FILES -l log_config.txt -s mta_static_data/stops.txt >> current_status_all_lines\""
-bash -c "./mta $ALL_FILES -l log_config.txt -s mta_static_data/stops.txt >> current_status_all_lines"
+echo "bash -c \"./mta $ALL_FILES -l log_config.txt -s mta_static_data/stops.txt \""
+bash -c "./mta $ALL_FILES -l log_config.txt -s mta_static_data/stops.txt "
 
 echo "done"

--- a/src/file_parser.cpp
+++ b/src/file_parser.cpp
@@ -96,7 +96,7 @@ bool FileParser::parse_file(StaticData* sd)
             LOG4CXX_DEBUG(fileparser_logger, k_all_trips[i]);
         }
         
-        LOG4CXX_INFO(fileparser_logger, "Count of trips in file: " << k_filepath << ": " << k_all_trips.size());
+        LOG4CXX_DEBUG(fileparser_logger, "Count of trips in file: " << k_filepath << ": " << k_all_trips.size());
     }
     else 
     {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,8 +4,7 @@
 #include <stdlib.h>
 #include <string>
 #include <unistd.h>
-
-#include "log4cxx/logger.h"
+#include "log4cxx/logger.h" 
 #include "log4cxx/propertyconfigurator.h"
 
 #include "static_data_parser.hh"
@@ -146,24 +145,23 @@ int main(int argc, char* argv[])
 
     }
 
-    // TripMap is string is unique {tripid:[vector of trip updates]}
-    // We can iter it and find trips with > 1 update and dump their updates in chrono order!
+    // Find the trip with the most updates and print it
     TripMap::TripMapIterator it;
+    TripMap::TripMapIterator trip_with_most_updates;
     it = tm.begin();
+    
+    size_t largest_seen = 0;
     while (it != tm.end())
     {
-        if (it->second.size() > 1)
+        if (it->second.size() > largest_seen)
         {
-            LOG4CXX_INFO(main_logger, "Found trip with >1 update: " << it->second);
+            largest_seen = it->second.size();
+            trip_with_most_updates = it;
         }
         it++;
     }
-
+    LOG4CXX_INFO(main_logger, "Trip with most updates: " << trip_with_most_updates->second);
     LOG4CXX_INFO(main_logger, "Done parsing files, TripMap size: " << tm.size());
-
-    TripInfoVec vec_of_a_trip = tm.get_trips(a_trip_id);
-    LOG4CXX_INFO(main_logger, "Dumping single trip, trip_id: " << a_trip_id << ", updates: " << vec_of_a_trip);
-
 
 	return 0;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -163,6 +163,8 @@ int main(int argc, char* argv[])
     LOG4CXX_INFO(main_logger, "Trip with most updates: " << trip_with_most_updates->second);
     LOG4CXX_INFO(main_logger, "Done parsing files, TripMap size: " << tm.size());
 
+
+
 	return 0;
 }
 


### PR DESCRIPTION
* Stop redirecting output, use a `FileAppender` instead
* Use DEBUG mode for certain things to reduce output
* Add supplementary data for stops.txt, which can be `cat`'d onto the original `stops.txt` to provide info for 2 semi-legitimate stops (see `TribalKnowledge.md`)
* Only print the trip with the most updates, rather than all trips with >1 update (though this will also go away in the future)