### PR TITLE
Add basic query feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ current_status*
 TODO*
 mta_debug
 log4cxx
+mta.log

--- a/TribalKnowledge.md
+++ b/TribalKnowledge.md
@@ -18,3 +18,8 @@ There are at least 2 Unknown StopIDs: `R60` and `R65`. These show up in the feed
  
 I'll likely either ignore these, or add an extension to `stops.txt` for my own purposes because even if neither is a station, it's interesting data. I'd guess the time to cross the tunnel is a few minutes more than most intra-station times anyway, so could be another piece of data to add in, even if questionably reliable.
 
+## The `H` line
+
+* The H line was an earlier (not the only, and not the earliest) designation for what is now known as the Rockaway Park Shuttle, out in Queens. It's still listed as the H line in the data, even though most people would recognize it only by the S with a superscript R, like S^R. The superscript distinguishes it from the plain S line, which is the Grand Central Shuttle, and the S^F line, which is the Franklin Avenue Shuttle.
+* More here: https://en.wikipedia.org/wiki/Rockaway_Park_Shuttle
+

--- a/makefile
+++ b/makefile
@@ -3,7 +3,7 @@ GCC=g++
 TARGET=mta
 TARGET_DEBUG=mta_debug
 PROTOBUFS=src/protobufs/gtfs-realtime.pb.cc src/protobufs/nyct-subway.pb.cc
-DEPS=src/basic_structures.cpp src/time_parser.cpp src/utils.cpp src/trip_map.cpp src/static_data_parser.cpp src/file_parser.cpp
+DEPS=src/basic_structures.cpp src/time_parser.cpp src/utils.cpp src/trip_map.cpp src/static_data_parser.cpp src/file_parser.cpp src/query_interface.cpp
 MAIN=src/main.cpp
 FLAGS=-std=c++17 -lprotobuf -llog4cxx
 

--- a/src/basic_structures.hh
+++ b/src/basic_structures.hh
@@ -10,6 +10,7 @@
 
 
 struct PositionInfo{
+    std::string current_stop_id;
     std::string current_stop;
     int timestamp;
 };

--- a/src/file_parser.cpp
+++ b/src/file_parser.cpp
@@ -78,6 +78,7 @@ bool FileParser::parse_file(StaticData* sd)
                     // Combine this with timestamp to know where it is and when
                     if (vehicle_pos.has_stop_id()){
                         // Train is at a station, parse where it is and the timestamp
+                        ti.pi.current_stop_id = vehicle_pos.stop_id();
                         ti.pi.current_stop = sd->get_stop_name(vehicle_pos.stop_id());
                         ti.pi.timestamp = vehicle_pos.has_timestamp() ? vehicle_pos.timestamp() : -1;
                     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -163,7 +163,43 @@ int main(int argc, char* argv[])
     LOG4CXX_INFO(main_logger, "Trip with most updates: " << trip_with_most_updates->second);
     LOG4CXX_INFO(main_logger, "Done parsing files, TripMap size: " << tm.size());
 
+    // Now that the stuff is loaded, let's allow the user to query
+    // I guess we'll need an index at some point, 
+    // but for now let's go on the basis of stations and just iter the TripMap
+    // We can optimize for read later on, and have map of stations -> trains in the future
+    // Or even a map of stations -> expected trains in N minutes (which is really what is useful)
+    // But for now: simple query
+    
+    std::string input;
+    it = tm.begin();
+    std::cout << "Enter serch query (or 'exit'): " << std::endl;
+    while (std::getline(std::cin, input))
+    {
+        // While we read input fine and it's not 'exit'
+        // continue taking search terms
+        if (input.compare("exit") == 0)
+        {
+            std::cout << "you've exited, bye!" << std::endl;
+            break;
+        }
 
+        // Print the results and clear results for next search
+        std::cout << "Results for search term: " << input << "\n";
+        while (it != tm.end())
+        {
+            // magic number: 0 index is most recent update
+            if (it->second[0].pi.current_stop.find(input) != std::string::npos) 
+            {
+                std::cout << '\t' << it->second[0] << '\n';
+            }
+            it++;
+        }
+
+        // Clear out input
+        input.clear();
+        it = tm.begin();
+        std::cout << "Enter serch query (or 'exit'): " << std::endl;
+    }
 
 	return 0;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -10,6 +10,7 @@
 #include "static_data_parser.hh"
 #include "file_parser.hh"
 #include "trip_map.hh"
+#include "query_interface.hh"
 #include "utils.hh"
 
 struct CLIArgs {
@@ -163,44 +164,7 @@ int main(int argc, char* argv[])
     LOG4CXX_INFO(main_logger, "Trip with most updates: " << trip_with_most_updates->second);
     LOG4CXX_INFO(main_logger, "Done parsing files, TripMap size: " << tm.size());
 
-    // Now that the stuff is loaded, let's allow the user to query
-    // I guess we'll need an index at some point, 
-    // but for now let's go on the basis of stations and just iter the TripMap
-    // We can optimize for read later on, and have map of stations -> trains in the future
-    // Or even a map of stations -> expected trains in N minutes (which is really what is useful)
-    // But for now: simple query
-    
-    std::string input;
-    it = tm.begin();
-    std::cout << "Enter serch query (or 'exit'): " << std::endl;
-    while (std::getline(std::cin, input))
-    {
-        // While we read input fine and it's not 'exit'
-        // continue taking search terms
-        if (input.compare("exit") == 0)
-        {
-            std::cout << "you've exited, bye!" << std::endl;
-            break;
-        }
-
-        // Print the results and clear results for next search
-        std::cout << "Results for search term: " << input << "\n";
-        while (it != tm.end())
-        {
-            // magic number: 0 index is most recent update
-            if (it->second[0].pi.current_stop.find(input) != std::string::npos) 
-            {
-                std::cout << '\t' << it->second[0] << '\n';
-            }
-            it++;
-        }
-
-        // Clear out input
-        input.clear();
-        it = tm.begin();
-        std::cout << "Enter serch query (or 'exit'): " << std::endl;
-    }
-
+    query_tripmap(tm); 
 	return 0;
 }
 

--- a/src/query_interface.cpp
+++ b/src/query_interface.cpp
@@ -1,0 +1,82 @@
+// Implement query interface to get input from CLI user
+
+#include <iostream>
+#include <map>
+#include <string>
+
+#include "trip_map.hh"
+
+
+bool query_tripmap(TripMap& tm)
+{
+
+    // Now that the stuff is loaded, let's allow the user to query
+    // I guess we'll need an index at some point, 
+    // but for now let's go on the basis of stations and just iter the TripMap
+    // We can optimize for read later on, and have map of stations -> trains in the future
+    // Or even a map of stations -> expected trains in N minutes (which is really what is useful)
+    // But for now: simple query
+    std::map<std::string, TripInfoVec> station_to_trips;
+    std::map<std::string, TripInfoVec>::iterator stt;
+    
+    std::string input;
+    TripMap::TripMapIterator it;
+    it = tm.begin();
+    std::cout << "Enter serch query (or 'quit'): " << std::endl;
+    while (std::getline(std::cin, input))
+    {
+        // While we read input fine and it's not 'quit'
+        // continue taking search terms
+        if (input.compare("quit") == 0)
+        {
+            std::cout << "goodbye!" << std::endl;
+            break;
+        }
+
+        // Print the results and clear results for next search
+        std::cout << "Results for search term: " << input << "\n";
+        while (it != tm.end())
+        {
+            // magic number: 0 index is most recent update
+            // Make map of station->[tiv] so we can distinguish when printing
+            if (it->second[0].pi.current_stop.find(input) != std::string::npos) 
+            {
+                std::string cstop_id = it->second[0].pi.current_stop_id;
+                // Insert to map 
+                stt = station_to_trips.find(cstop_id);
+                if (stt == station_to_trips.end())
+                {
+                    // Not found, insert it
+                    TripInfoVec tiv;
+                    tiv.push_back(it->second[0]);
+                    station_to_trips.insert(std::pair<std::string, TripInfoVec>(cstop_id,tiv));
+                } 
+                else
+                {
+                    // Found it, just append
+                    stt->second.push_back(it->second[0]);
+                }
+                
+            }
+            it++;
+        }
+        
+        // Iter the station_to_trips map and dump output
+        stt = station_to_trips.begin();
+        while (stt != station_to_trips.end())
+        {
+            for (int i = 0; i < stt->second.size(); i++)
+            {
+                std::cout << '\t' << stt->second[i] << '\n';
+            }
+            stt++;
+        }
+
+        // Clear out input
+        station_to_trips.clear();
+        input.clear();
+        it = tm.begin();
+        std::cout << "Enter serch query (or 'quit'): " << std::endl;
+    }
+    return true;
+}

--- a/src/query_interface.hh
+++ b/src/query_interface.hh
@@ -1,0 +1,8 @@
+// Implement query interface to get input from CLI user
+
+
+#include <iostream>
+#include <string>
+
+
+bool query_tripmap(TripMap& tm);


### PR DESCRIPTION
* Allows user to query from cmd line for trains currently at a specific station, until they enter `quit`
* I also added the stop ID to the `PositionInfo` struct so we can group by a unique identifier, as many stations have the same name, but are actually in different places, e.g.: 
  * 96th Street is a station for the 1/2/3, the B/C, and the 6 in 3 different stations in Manhattan alone
  * Prospect Avenue is in both Brooklyn and Da Bronx
  * 23rd street in Manhattan has 5 different stations: 8th avenue (C/E), 7th avenue (1), 6th avenue (F/M), Broadway/5th (R/W), and Park Avenue South (6)

Fixes the makefile for this as well.

