### PR TITLE
Get data in cpp

### DIFF
--- a/makefile
+++ b/makefile
@@ -3,9 +3,9 @@ GCC=g++
 TARGET=mta
 TARGET_DEBUG=mta_debug
 PROTOBUFS=src/protobufs/gtfs-realtime.pb.cc src/protobufs/nyct-subway.pb.cc
-DEPS=src/basic_structures.cpp src/time_parser.cpp src/utils.cpp src/trip_map.cpp src/static_data_parser.cpp src/file_parser.cpp src/query_interface.cpp
+DEPS=src/basic_structures.cpp src/time_parser.cpp src/utils.cpp src/trip_map.cpp src/static_data_parser.cpp src/file_parser.cpp src/query_interface.cpp src/retriever.cpp
 MAIN=src/main.cpp
-FLAGS=-std=c++17 -lprotobuf -llog4cxx
+FLAGS=-std=c++17 -lprotobuf -llog4cxx -lcurl
 
 all:
 	$(GCC) -o $(TARGET) $(PROTOBUFS) $(DEPS) $(MAIN) $(FLAGS)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -38,9 +38,9 @@ std::ostream& operator<<(std::ostream& os, const struct CLIArgs& args)
     os << "route = " << args.route << ", ";
     os << "stops_txt_filename = " << args.stops_txt_filename << ", ";
     os << "log_config = " << args.log_config << ", ";
+    os << "daemon_mode= " << std::boolalpha << args.daemon_mode << ", ";
+    os << "new_data= " << std::boolalpha << args.new_data << ", ";
     os << "data_filenames = ";
-    os << "daemon_mode= " << std::boolalpha << args.daemon_mode;
-    os << "new_data= " << std::boolalpha << args.new_data;
 
     for (int i = 0; i < args.filenames.size(); i++)
     {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -23,6 +23,12 @@ struct CLIArgs {
     std::vector<std::string> filenames;	
 	std::string stops_txt_filename;	
     bool daemon_mode;
+    bool new_data;
+
+    CLIArgs(){
+        daemon_mode = false;
+        new_data = false;
+    }
 };
 
 std::ostream& operator<<(std::ostream& os, const struct CLIArgs& args)
@@ -49,6 +55,7 @@ static void show_usage(void)
           << "-l|--log-config LOG_CONFIG_FILENAME\n"
           << "-f|--filename FILENAME\n"
           << "[-D|--Daemon]"
+          << "[-n|--new-data]"
           << "[-v|--verbose]"
 		  << std::endl; 
 }
@@ -58,7 +65,6 @@ log4cxx::LoggerPtr main_logger(log4cxx::Logger::getLogger("mta"));
 int main(int argc, char* argv[])
 {
 	CLIArgs args;
-    args.daemon_mode = false;
 	
 	// sanity check	
 	if (argc <= 1)
@@ -71,7 +77,7 @@ int main(int argc, char* argv[])
 
 	// parse out	
 	int c;	
-	while((c = getopt(argc, argv, "s:d:D:r:l:v::f:")) != -1 )
+	while((c = getopt(argc, argv, "n:s:d:D:r:l:v::f:")) != -1 )
 	{
 		switch (c)
 		{
@@ -102,6 +108,9 @@ int main(int argc, char* argv[])
 			case 'D':
                 args.daemon_mode = true;
 				break;
+			case 'n':
+                args.new_data = true;
+				break;
 		}
 	}
 
@@ -112,11 +121,17 @@ int main(int argc, char* argv[])
 
     LOG4CXX_INFO(main_logger, "Arguments given:" << args);
     // Get files from MTA here if no filename given
-    //if (!args.filename)
-    //{
-    //    // Get data from MTA here
-    //    std::cout << "Getting data from MTA..." << std::endl;
-    //}
+    if (args.new_data || args.filenames.size() == 0)
+    {
+        if (!get_mta_data())
+        {
+            LOG4CXX_ERROR(main_logger, "Getting data from MTA...");
+        }
+        else
+        {
+            LOG4CXX_INFO(main_logger, "Getting data from MTA...");
+        }
+    }
 
     // Parse stops.txt
     StaticData sd;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,14 +3,16 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string>
+#include <thread>
 #include <unistd.h>
 #include "log4cxx/logger.h" 
 #include "log4cxx/propertyconfigurator.h"
 
-#include "static_data_parser.hh"
 #include "file_parser.hh"
-#include "trip_map.hh"
+#include "retriever.hh"
+#include "static_data_parser.hh"
 #include "query_interface.hh"
+#include "trip_map.hh"
 #include "utils.hh"
 
 struct CLIArgs {
@@ -20,6 +22,7 @@ struct CLIArgs {
 	std::string log_config;	
     std::vector<std::string> filenames;	
 	std::string stops_txt_filename;	
+    bool daemon_mode;
 };
 
 std::ostream& operator<<(std::ostream& os, const struct CLIArgs& args)
@@ -45,6 +48,7 @@ static void show_usage(void)
 		  << "-r|--route [1|2|3|4|5|6|7|S|A|C|E|B|D|F|M|J|Z|G ... \n"
           << "-l|--log-config LOG_CONFIG_FILENAME\n"
           << "-f|--filename FILENAME\n"
+          << "[-D|--Daemon]"
           << "[-v|--verbose]"
 		  << std::endl; 
 }
@@ -54,6 +58,7 @@ log4cxx::LoggerPtr main_logger(log4cxx::Logger::getLogger("mta"));
 int main(int argc, char* argv[])
 {
 	CLIArgs args;
+    args.daemon_mode = false;
 	
 	// sanity check	
 	if (argc <= 1)
@@ -66,7 +71,7 @@ int main(int argc, char* argv[])
 
 	// parse out	
 	int c;	
-	while((c = getopt(argc, argv, "s:d:r:l:v::f:")) != -1 )
+	while((c = getopt(argc, argv, "s:d:D:r:l:v::f:")) != -1 )
 	{
 		switch (c)
 		{
@@ -93,6 +98,9 @@ int main(int argc, char* argv[])
 				break;
 			case 'v':
                 set_log_debug = true;
+				break;
+			case 'D':
+                args.daemon_mode = true;
 				break;
 		}
 	}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -39,6 +39,8 @@ std::ostream& operator<<(std::ostream& os, const struct CLIArgs& args)
     os << "stops_txt_filename = " << args.stops_txt_filename << ", ";
     os << "log_config = " << args.log_config << ", ";
     os << "data_filenames = ";
+    os << "daemon_mode= " << std::boolalpha << args.daemon_mode;
+    os << "new_data= " << std::boolalpha << args.new_data;
 
     for (int i = 0; i < args.filenames.size(); i++)
     {

--- a/src/query_interface.hh
+++ b/src/query_interface.hh
@@ -1,8 +1,9 @@
 // Implement query interface to get input from CLI user
 
-
 #include <iostream>
 #include <string>
+
+#include "trip_map.hh"
 
 
 bool query_tripmap(TripMap& tm);

--- a/src/retriever.cpp
+++ b/src/retriever.cpp
@@ -1,0 +1,109 @@
+// Testing out accessing the web via cpp
+
+#include "retriever.hh"
+
+typedef std::map<const char*, const char*> StringMap;
+typedef std::pair<const char*, const char*> StringMapPair;
+typedef std::map<const char*, const char*>::iterator StringMapIter;
+
+static size_t write_data(void* ptr, size_t size, size_t nmemb, void* stream)
+{
+	size_t written = fwrite(ptr, size, nmemb, (FILE*)stream);
+	return written;
+}
+
+bool get_data_for_mta_sites(StringMap* map_ptr, CURL*& handle)
+{
+    // Assumes handle is read to go 
+
+	// basic setup 
+	FILE* output_file; 
+	CURLcode rc;
+
+	// create iterator to beginning of map
+    StringMapIter iter;
+	iter = map_ptr->begin();
+
+	// iter and make calls
+	while (iter != map_ptr->end())
+	{
+		// open output file
+		output_file = fopen(iter->second, "wb");
+		if (!output_file)
+		{
+			curl_easy_cleanup(handle);
+			std::cerr << "Error opening file: " << iter->second << std::endl;
+			return false;
+		}
+
+        // set up the source, destination, and API Key
+        // This is done on a per-connection / per-header basis, so can't be done sooner
+        curl_easy_setopt(handle, CURLOPT_WRITEDATA, output_file);
+        curl_easy_setopt(handle, CURLOPT_URL, iter->first);
+        
+        // Set up api key in header
+        struct curl_slist* header = NULL;
+        std::string kv("x-api-key:");
+        kv.append(getenv("MTAKEY"));
+
+        header = curl_slist_append(header, kv.c_str());
+        if (header == NULL)
+        {
+            std::cerr << "problem appending to header!" << std::endl;
+            // close out and flush
+            fclose(output_file);
+            return false;
+        }
+        curl_easy_setopt(handle, CURLOPT_HTTPHEADER, header);
+
+        // Do the call
+		rc = curl_easy_perform(handle);
+
+		// close out and flush
+		fclose(output_file);
+
+        // Error check
+        if (rc != CURLE_OK)
+        {
+			std::cerr << "Something went wrong for: " << iter->first << " : " << curl_easy_strerror(rc) << std::endl;
+            std::cerr << "curl_easy_perform failed: " << curl_easy_strerror(rc) << std::endl;
+            std::cerr << "Status code for site: " << iter->first << ": " << curl_easy_strerror(rc) << std::endl;
+            return false;
+        }
+        else 
+        {
+			std::cout << "Data successfully retrieved for: " << iter->first << std::endl;
+        }
+	
+		iter++;
+	}
+    return true;
+}
+
+bool get_mta_data(void)
+{
+    // instantiation
+    CURL* handle;
+    curl_global_init(CURL_GLOBAL_ALL);
+    handle = curl_easy_init();
+
+    // some option setting
+    curl_easy_setopt(handle, CURLOPT_WRITEFUNCTION, write_data);
+
+    // create the map of url:filename
+    StringMap url_and_outfile;
+    url_and_outfile.insert(StringMapPair("https://api-endpoint.mta.info/Dataservice/mtagtfsfeeds/nyct%2Fgtfs-bdfm", "gtfs.bfdm.data"));
+
+    // do the thing	
+    bool rc = get_data_for_mta_sites(&url_and_outfile, handle);
+
+    // clean up
+    curl_easy_cleanup(handle);
+
+    if (rc == false)
+    {
+        std::cerr << "Problem during getting data for sites!" << std::endl;
+    }
+    return rc == true;
+}
+

--- a/src/retriever.cpp
+++ b/src/retriever.cpp
@@ -121,10 +121,11 @@ std::vector<std::string> get_mta_data()
     {
         if (extensions[i] == std::string("1234567"))
         {
-            // special case for 1234567, url does not have a '-' after gtfs
+            // special case for 1234567
+            // The url does not have a line specifier!
             tmpurl = url;
-            tmpurl.append(extensions[i]);
 
+            // We do want to have the outfile with the extension though
             tmpoutfile = outfile;
             tmpoutfile.append(extensions[i]);
         }
@@ -138,7 +139,6 @@ std::vector<std::string> get_mta_data()
             // no dash for outfile though
             tmpoutfile = outfile;
             tmpoutfile.append(extensions[i]);
-
         }
 
         // Get time for file

--- a/src/retriever.cpp
+++ b/src/retriever.cpp
@@ -136,21 +136,22 @@ bool get_mta_data(void)
             tmpoutfile = outfile;
             tmpoutfile.append(extensions[i]);
 
-            // YYYYMMDDHHMMSS date for filename
-            std::time_t rawtime;
-            std::tm* timeinfo;
-            char buffer[14];
-
-            std::time(&rawtime);
-            timeinfo = std::localtime(&rawtime);
-
-            std::strftime(buffer, 14,"%Y%m%d%H%M%S", timeinfo);
-            std::puts(buffer);
-
-            std::string curtime(buffer, 14);
-
-            tmpoutfile.append(curtime);
         }
+        // YYYYMMDDHHMMSS date for filename
+        std::time_t rawtime;
+        std::tm* timeinfo;
+        char buffer[14];
+
+        std::time(&rawtime);
+        timeinfo = std::localtime(&rawtime);
+
+        std::strftime(buffer, 14,"%Y%m%d%H%M%S", timeinfo);
+        std::puts(buffer);
+
+        std::string curtime(buffer, 14);
+
+        tmpoutfile.append("_");
+        tmpoutfile.append(curtime);
         url_and_outfile.insert(StringMapPair(tmpurl.c_str(), tmpoutfile.c_str()));
     }
 

--- a/src/retriever.cpp
+++ b/src/retriever.cpp
@@ -108,7 +108,7 @@ std::vector<std::string> get_mta_data()
     extensions.push_back("nqrw");
     extensions.push_back("l");
     extensions.push_back("si");
-    //extensions.push_back("1234567");
+    extensions.push_back("1234567");
 
     // Fill it
     std::string url;

--- a/src/retriever.hh
+++ b/src/retriever.hh
@@ -7,18 +7,20 @@
 #include <unistd.h>
 #include <iostream>
 #include <map>
+#include <vector>
+#include <string>
 
 #include <curl/curl.h>
 
-typedef std::map<const char*, const char*> StringMap;
-typedef std::pair<const char*, const char*> StringMapPair;
-typedef std::map<const char*, const char*>::iterator StringMapIter;
+typedef std::map<std::string, std::string> StringMap;
+typedef std::pair<std::string, std::string> StringMapPair;
+typedef std::map<std::string, std::string>::iterator StringMapIter;
 
 static size_t write_data(void* ptr, size_t size, size_t nmemb, void* stream);
 
 bool get_data_for_mta_sites(StringMap* map_ptr, CURL*& handle);
 
-bool get_mta_data(void);
+std::vector<std::string> get_mta_data();
 
 
 #endif // MTA_RETRIEVER header guard

--- a/src/retriever.hh
+++ b/src/retriever.hh
@@ -1,0 +1,18 @@
+// Testing out accessing the web via cpp
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <iostream>
+#include <map>
+
+#include <curl/curl.h>
+
+typedef std::map<const char*, const char*> StringMap;
+typedef std::pair<const char*, const char*> StringMapPair;
+typedef std::map<const char*, const char*>::iterator StringMapIter;
+
+static size_t write_data(void* ptr, size_t size, size_t nmemb, void* stream);
+
+bool get_data_for_mta_sites(StringMap* map_ptr, CURL*& handle);
+
+bool get_mta_data(void);

--- a/src/retriever.hh
+++ b/src/retriever.hh
@@ -1,3 +1,6 @@
+#ifndef MTA_RETRIEVER
+#define MTA_RETRIEVER
+
 // Testing out accessing the web via cpp
 #include <stdio.h>
 #include <stdlib.h>
@@ -16,3 +19,6 @@ static size_t write_data(void* ptr, size_t size, size_t nmemb, void* stream);
 bool get_data_for_mta_sites(StringMap* map_ptr, CURL*& handle);
 
 bool get_mta_data(void);
+
+
+#endif // MTA_RETRIEVER header guard


### PR DESCRIPTION
* This started as an attempt to daemonize but in reality this needed to be done only after I could get data from the MTA in cpp code, rather than with a helper shell script `get_realtime_data.sh`
* So anyway, this PR adds the feature to get data from the MTA 
* And integrates it into the main under the `-n|--new-data` switch, so it can be used in lieu of the `-f|--filename` switch OR in conjunction with it

Still some cleanup to do though